### PR TITLE
Expose SF Python connector autocommit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ In order to run snowchange you must have the following:
 snowchange is a single python script named [snowchange.py](snowchange.py). It can be executed as follows:
 
 ```
-python snowchange.py [-h] [-f ROOT_FOLDER] -a SNOWFLAKE_ACCOUNT --snowflake-region SNOWFLAKE_REGION -u SNOWFLAKE_USER -r SNOWFLAKE_ROLE -w SNOWFLAKE_WAREHOUSE  [-c CHANGE_HISTORY_TABLE] [-v]
+python snowchange.py [-h] [-f ROOT_FOLDER] -a SNOWFLAKE_ACCOUNT --snowflake-region SNOWFLAKE_REGION -u SNOWFLAKE_USER -r SNOWFLAKE_ROLE -w SNOWFLAKE_WAREHOUSE  [-c CHANGE_HISTORY_TABLE] [-v] [-ac]
 ```
 
 The Snowflake user password for `SNOWFLAKE_USER` is required to be set in the environment variable `SNOWSQL_PWD` prior to calling the script. snowchange will fail if the `SNOWSQL_PWD` environment variable is not set.
@@ -133,6 +133,7 @@ Parameter | Description
 -r SNOWFLAKE_ROLE, --snowflake-role SNOWFLAKE_ROLE | The name of the role to use (e.g. DEPLOYER_ROLE)
 -w SNOWFLAKE_WAREHOUSE, --snowflake-warehouse SNOWFLAKE_WAREHOUSE | The name of the warehouse to use (e.g. DEPLOYER_WAREHOUSE)
 -c CHANGE_HISTORY_TABLE, --change-history-table CHANGE_HISTORY_TABLE | Used to override the default name of the change history table (e.g. METADATA.SNOWCHANGE.CHANGE_HISTORY)
+-ac, --autocommit | A signal for Snowflake Python connector to enable autocommit feature for DML commands.
 -v, --verbose | Display verbose debugging details during execution
 
 ## Getting Started with snowchange
@@ -165,7 +166,7 @@ Here is a sample DevOps development lifecycle with snowchange:
 If your build agent has a recent version of python 3 installed, the script can be ran like so:
 ```
 pip install --upgrade snowflake-connector-python
-python snowchange.py [-h] [-f ROOT_FOLDER] -a SNOWFLAKE_ACCOUNT --snowflake-region SNOWFLAKE_REGION -u SNOWFLAKE_USER -r SNOWFLAKE_ROLE -w SNOWFLAKE_WAREHOUSE  [-c CHANGE_HISTORY_TABLE] [-v]
+python snowchange.py [-h] [-f ROOT_FOLDER] -a SNOWFLAKE_ACCOUNT --snowflake-region SNOWFLAKE_REGION -u SNOWFLAKE_USER -r SNOWFLAKE_ROLE -w SNOWFLAKE_WAREHOUSE  [-c CHANGE_HISTORY_TABLE] [-v] [-ac]
 ```
 
 Or if you prefer docker, set the environment variables and run like so:


### PR DESCRIPTION
PROBLEM
---------------
By default Snowchange enables 'autocommit' for Snowflake Python connector. If one of the multiple DML commands fails within a single script, all the commands before the failed one don't get rolled back. 

Consider the example below:
1. We have no control over command 1 and 2, because they are DDL operations, Snowflake always auto commits DDL commands regardless the 'autocommit' setting. (https://docs.snowflake.com/en/sql-reference/transactions.html). 
2. However, with the default 'autocommit' setting (True), when a DML command 4 fails, command 3 change will get applied, which is problematic and may cause side effects.
```
-- 1. Set the database and schema context
USE SCHEMA MY_DB.PUBLIC;

-- 2. Create sample table (DDL operation)
CREATE TABLE IF NOT EXISTS sample_table (
    id INT PRIMARY KEY
    ,name
)

-- 3. Insert correct data into sample table (DML operation)
INSERT INTO sample_table (
    id
    ,name
) VALUES (
    1
    ,'shawn'
);

-- 4. Insert incorrect data into sample table (DML operation)
-- THIS COMMAND WILL FAIL DUE TO "invalid identifier 'EMAIL'"
INSERT INTO sample_table (
    id
    ,name
    ,email
) VALUES (
    2
    ,'james'
    ,'james@snowchange.com'
);

```

PROPOSED SOLUTION
--------------- 
Instead of default 'autocommit' setting to True:
1. Allow users to choose whether they want to enable auto commit feature or not
2. By default disable auto commit feature, to prevent incorrect DML commands being applied partially during schema/ data migration